### PR TITLE
#1 added the side nav to the header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,5 +84,10 @@ a {
 }
 
 .redBackground {
-  background-color: #a7171a
+  background-color: #a7171a;
+}
+
+.linkNoDecoration {
+  color: rgb(0, 0, 0, 0.87);
+  text-decoration: none;
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -4,6 +4,7 @@ import { AppBar, Toolbar, IconButton, Slide } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import React from 'react';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
+import SideNav from './SideNav';
 
 const useStyles = makeStyles(theme => ({
 
@@ -34,12 +35,14 @@ export default function Header(props) {
             <HideOnScroll {...props}>
                 <AppBar>
                     <Toolbar className={classes.navBar}>
+                        <SideNav />
                         <a className={classes.header} href ="/">
+                            Garden State Performance
                             <IconButton
                                 edge="start"
                                 aria-label="home"
                                 style={{
-                                    marginRight: "5px"
+                                    marginLeft: "5px"
                                 }}
                             >
                                 <img 
@@ -49,7 +52,6 @@ export default function Header(props) {
                                     src={Logo}
                                     alt="Garden State Performance Logo" />
                             </IconButton>
-                            Garden State Performance
                         </a>
                     </Toolbar>
                 </AppBar>

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -1,0 +1,115 @@
+
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Drawer from '@mui/material/Drawer';
+import Button from '@mui/material/Button';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import MenuIcon from '@mui/icons-material/Menu';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import FitnessCenterIcon from '@mui/icons-material/FitnessCenter';
+
+export default function SideNav() {
+    const [state, setState] = React.useState({
+        left: false
+    });
+
+    const toggleDrawer = (anchor, open) => (event) => {
+        if (event.type === 'keydown' && (event.key === 'Tab' || event.key === 'Shift')) {
+            return;
+        }
+
+        setState({ ...state, [anchor]: open });
+    }
+
+    const list = (anchor) => (
+        <Box
+            sx={{ width: anchor === 'top' || anchor === 'bottom' ? 'auto' : 250 }}
+            role="presentation"
+            onClick={toggleDrawer(anchor, false)}
+            onKeyDown={toggleDrawer(anchor, false)}
+        >
+            <List>
+                <a className='linkNoDecoration' href="/">
+                    <ListItem disablePadding>
+                        <ListItemButton>
+                            <ListItemIcon>
+                                <img src="/logo192.png"
+                                    style={{
+                                        width: "24px",
+                                        height: "24px"
+                                    }}
+                                    alt="Home"
+                                />
+                            </ListItemIcon>
+                            <ListItemText>
+                            Home
+                            </ListItemText>
+                        </ListItemButton>
+                    </ListItem>
+                </a>
+
+                <a className='linkNoDecoration' href="/about">
+                    <ListItem disablePadding>
+                        <ListItemButton>
+                            <ListItemIcon>
+                                <AccountCircleIcon />
+                            </ListItemIcon>
+                            <ListItemText>
+                                About GSP
+                            </ListItemText>
+                        </ListItemButton>
+                    </ListItem>
+                </a>
+
+                <a className='linkNoDecoration' href="/programming">
+                    <ListItem disablePadding>
+                        <ListItemButton>
+                            <ListItemIcon>
+                                <FitnessCenterIcon />
+                            </ListItemIcon>
+                            <ListItemText>
+                                Our Programming
+                            </ListItemText>
+                        </ListItemButton>
+                    </ListItem>
+                </a>
+
+                <a className='linkNoDecoration' href="/hours">
+                    <ListItem disablePadding>
+                        <ListItemButton>
+                            <ListItemIcon>
+                                <ScheduleIcon />
+                            </ListItemIcon>
+                            <ListItemText>
+                                Hours
+                            </ListItemText>
+                        </ListItemButton>
+                    </ListItem>
+                </a>
+            </List>
+
+        </Box>
+    );
+
+    return (
+        <div>
+ 
+            <React.Fragment key={'left'}>
+            <Button onClick={toggleDrawer('left', true)}><MenuIcon style={{color: "white"}} /></Button>
+            <Drawer
+                anchor={'left'}
+                open={state['left']}
+                onClose={toggleDrawer('left', false)}
+            >
+                {list('left')}
+            </Drawer>
+            </React.Fragment>
+        
+        </div>
+    )
+}


### PR DESCRIPTION
Closes ticket #1 

Work in this PR
- Created Hours Page
- Created About GSP page
- Created Our Programming page
- Created Side nav in the header
- Updated text on home page 

Screenshots
![image](https://user-images.githubusercontent.com/12487924/193428174-d4fef45c-4dc3-46e0-8cff-70b5ba0422fa.png)
New side nav

![image](https://user-images.githubusercontent.com/12487924/193428183-8974300e-527d-45aa-a01f-751759163d63.png)
Hours page

![image](https://user-images.githubusercontent.com/12487924/193428189-53f37660-90e9-4dae-bbbf-12c25c27dda1.png)
About GSP page 

![image](https://user-images.githubusercontent.com/12487924/193428199-d2eb7d41-d0be-453b-b48f-ac538a52bf6c.png)
Our programming

Thoughts/Comments
verify that the menu addition to the header does not break the header (make it go to two lines)